### PR TITLE
Fix `teams()` to gracefully handle missing `syn.owner`

### DIFF
--- a/syn-teams.libsonnet
+++ b/syn-teams.libsonnet
@@ -184,7 +184,7 @@ local teams(includeOwner=false) =
     team
     for team in std.objectFields(teamApplicationMap)
     if
-      (includeOwner || team != inv.parameters.syn.owner) &&
+      (includeOwner || team != syn_owner) &&
       std.length(teamApplicationMap[team]) > 0
   ];
 


### PR DESCRIPTION
Use `syn_owner` instead of directly reading the parameter to skip the owner team if `includeOwner=false`.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
