### PR TITLE
Extend `allInstances` with the component names of instantiated components

### DIFF
--- a/syn-teams.libsonnet
+++ b/syn-teams.libsonnet
@@ -60,10 +60,15 @@ local appKeys(name, raw=false) =
 
 // Extract all instances from `inv.applications`.
 // The design doc (SDD-0030) specifies that entries in `syn.<team>.instances`
-// must be component instances, so we don't need to worry about the component
-// name for instantiated components.
+// must be component instances.
+// However, Commodore doesn't require that instance-aware components generate
+// an ArgoCD application per instance, and some existing components generate a
+// single ArgoCD application for all their instances. For such components,
+// individual instances can't be assigned to a team, but the whole component
+// can be assigned. To accommodate this design choice, we keep both the
+// instance and component name in allInstances for instantiated components.
 local allInstances = std.set(
-  std.map(function(app) appKeys(app, true)[0], inv.applications)
+  std.flattenArrays(std.map(function(app) appKeys(app, true), inv.applications))
 );
 
 


### PR DESCRIPTION
The design doc (SDD-0030) specifies that entries in `syn.<team>.instances` must be component instances.

However, Commodore doesn't require that instance-aware components generate an ArgoCD application per instance, and some existing components generate a single ArgoCD application for all their instances.

For such components, individual instances can't be assigned to a team, but the whole component can be assigned.

To accommodate this design choice, we keep both the instance and component names in `allInstances` for instantiated components. This ensures that library consumers can correctly look up the team for a component which generates a single ArgoCD application for all instances.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
