### PR TITLE
Fix comment and naming for `isMultiTeamAware`

### DIFF
--- a/syn-teams.libsonnet
+++ b/syn-teams.libsonnet
@@ -197,15 +197,18 @@ local teams(includeOwner=false) =
 /**
  * \brief Check if component instance with the given name supports ArgoCD * multi-tenancy
  *
- * \arg instance the component instance
+ * NOTE: This function must be called with the component name, since we won't
+ * have the component metadata in the instance's parameters key.
+ *
+ * \arg component the component name for the instance
  *
  * \returns true if component sets `._metadata.multi_tenant=true`, false otherwise
  */
-local isMultiTenantAware(instance) =
-  local ikey = appKeys(instance)[0];
-  local iparams = std.get(inv.parameters, ikey, {});
-  local imeta = std.get(iparams, '_metadata', {});
-  std.get(imeta, 'multi_tenant', false);
+local isMultiTenantAware(component) =
+  local ckey = appKeys(component)[0];
+  local cparams = std.get(inv.parameters, ckey, {});
+  local cmeta = std.get(cparams, '_metadata', {});
+  std.get(cmeta, 'multi_tenant', false);
 
 
 {


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
